### PR TITLE
Ensure beta signup button text is bold and white

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1407,6 +1407,7 @@ p {
   font-weight: 700;
   font-size: 18px;
   border-radius: 18px;
+  color: #fff;
 }
 
 @media (max-width: 767px) {


### PR DESCRIPTION
## Summary
- guarantee the beta signup button keeps bold white text by explicitly styling the subscribe-form button

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8898be45c8324aad2134613e273d7